### PR TITLE
fix(setup): Simplify the semantic release pipeline, removing the need…

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,27 +2,6 @@ branches:
   - main
 
 plugins:
-  - - "@semantic-release/commit-analyzer"
-    - preset: conventionalcommits
-      releaseRules:
-        - release: patch
-          type: perf
-        - release: patch
-          type: revert
-        - release: patch
-          type: docs
-        - release: patch
-          type: style
-        - release: patch
-          type: chore
-        - release: patch
-          type: refactor
-        - release: patch
-          type: test
-        - release: patch
-          type: build
+  - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - - "@semantic-release/git"
-    - assets:
-        - data_access/version.py
   - "@semantic-release/github"

--- a/data_access/__init__.py
+++ b/data_access/__init__.py
@@ -1,3 +1,0 @@
-from data_access.version import version
-
-__version__ = version

--- a/data_access/version.py
+++ b/data_access/version.py
@@ -1,1 +1,0 @@
-version = "0.0.1"  # pylint: disable=invalid-name


### PR DESCRIPTION
## Info

* Simplify the semantic release config
* Remove keeping the version of the release within the code

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
