### PR TITLE
fix: experimenting with deploying docs to gh-pages

### DIFF
--- a/.github/workflows/ci_merge.yml
+++ b/.github/workflows/ci_merge.yml
@@ -8,6 +8,8 @@ on:
 # Security permissions (enabling write access for documentation)
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -47,3 +49,12 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
+
+      # Deploy documentation to Github Pages
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GH_PAT }}
+          publish_dir: ./docs
+          keep_files: true


### PR DESCRIPTION
## Info

* Update merge CI to deploy docs to gh-pages (hopefully)

## References

* [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-first-deployment-with-github_token)

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
