### PR TITLE
fix: ensure `deploy` job runs after `build`

### DIFF
--- a/.github/workflows/ci_merge.yml
+++ b/.github/workflows/ci_merge.yml
@@ -64,6 +64,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
+    needs: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Info

* Add `build` job as dependency for `deploy` job when creating gh-pages docs

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
