### PR TITLE
fix: use root to upload entire repo of gh-pages branch

### DIFF
--- a/.github/workflows/ci_merge.yml
+++ b/.github/workflows/ci_merge.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
-          name: docs_data
-          path: docs/
+          path: .
           if-no-files-found: error
           overwrite: true
 


### PR DESCRIPTION
## Info

* Upload `.`, not `./docs`

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
