### PR TITLE
fix: rename uploaded docs artifact

### DIFF
--- a/.github/workflows/ci_merge.yml
+++ b/.github/workflows/ci_merge.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Upload documentation
         uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: .
           if-no-files-found: error
           overwrite: true


### PR DESCRIPTION
## Info

* Rename the uploaded docs artifact to `gitHub-pages` to match the deploy steps expectation

## References

* N/A

## Developer Checklist

- [ ] Linting has been locally completed on the code
- [ ] Formatting has been locally completed on the code
- [ ] Type-checking has been locally completed on the code
- [ ] Unit testing has been locally completed on the code
